### PR TITLE
Add SingleView.jsx

### DIFF
--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -1,4 +1,6 @@
+import { useState } from 'react';
 import MediaRow from './MediaRow';
+import SingleView from './SingleView';
 
 const mediaArray = [
     {
@@ -38,6 +40,9 @@ const mediaArray = [
   ];
 
   const Home = () => {
+    const [selectedItem, setSelectedItem] = useState(null);
+    
+    console.log('selectedItem', selectedItem);
     return (
       <>
         <h2>My Media</h2>
@@ -50,14 +55,16 @@ const mediaArray = [
               <th>Created</th>
               <th>Size</th>
               <th>Type</th>
+              <th>Operations</th>
             </tr>
           </thead>
           <tbody>
           {mediaArray.map((item) => (
-            <MediaRow key={item.media_id} item={item} />
+            <MediaRow key={item.media_id} item={item} setSelectedItem={setSelectedItem} />
             ))}
           </tbody>
         </table>
+        <SingleView item={selectedItem} setSelectedItem={setSelectedItem} />
       </>
     );
   };

--- a/src/components/MediaRow.jsx
+++ b/src/components/MediaRow.jsx
@@ -2,7 +2,12 @@ import PropTypes from "prop-types";
 
 // src/components/MediaRow.jsx
 const MediaRow = (props) => {
-    const {item} = props;
+
+const handleClick = () => {
+  setSelectedItem(item);
+}
+
+    const {item, setSelectedItem} = props;
     return (
       // TODO: move <tr> element in foreach from Home.jsx here
       <tr key={item.media_id}>
@@ -14,12 +19,16 @@ const MediaRow = (props) => {
                 <td>{new Date(item.created_at).toLocaleString('fi-FI')}</td>
                 <td>{item.filesize}</td>
                 <td>{item.media_type}</td>
+                <td>
+                  <button onClick={handleClick}>View</button>
+                </td>
               </tr>
     );
   };
 
   MediaRow.propTypes= {
     item: PropTypes.object.isRequired,
+    setSelectedItem: PropTypes.func.isRequired,
   }
 
   export default MediaRow;

--- a/src/components/SingleView.jsx
+++ b/src/components/SingleView.jsx
@@ -1,0 +1,22 @@
+const SingleView = (props) => {
+    const {item, setSelectedItem} = props;
+    return ( 
+      // TODO: Add JSX for displaying a mediafile here
+      // - use e.g. a <dialog> element for creating a modal
+      // - use item prop to render the media item details
+      // - use img tag for displaying images
+      // - use video tag for displaying videos
+
+      <>
+      {item && (
+      <dialog open>
+        <img src={item.filename} alt={item.title} />
+        <h3>Title: {item.title}</h3>
+        <p>{item.description}</p>
+      </dialog>
+      )}
+
+      </>
+    );
+  };
+  export default SingleView;


### PR DESCRIPTION
This pull request introduces a new feature to display a detailed view of media items in a modal when a user clicks on a "View" button. The most important changes include adding a new component, updating existing components to handle state, and modifying the media table to include the new functionality.

New feature implementation:

* [`src/components/SingleView.jsx`](diffhunk://#diff-e50be4fd2f1a1afa2795b9ecc7a86eb9f134ff998e1c1aabc1184db624e7d0d0R1-R22): Added a new `SingleView` component to display detailed information about a media item in a modal.

State management and event handling:

* [`src/components/Home.jsx`](diffhunk://#diff-8bc8933bf9f0a1dece53f0af6a1cf667e51f3286cc1d8aacebe87ff459e2960bR1-R3): Imported `useState` to manage the selected media item state, added a new state variable `selectedItem`, and updated the media table to include a new "Operations" column with a "View" button. [[1]](diffhunk://#diff-8bc8933bf9f0a1dece53f0af6a1cf667e51f3286cc1d8aacebe87ff459e2960bR1-R3) [[2]](diffhunk://#diff-8bc8933bf9f0a1dece53f0af6a1cf667e51f3286cc1d8aacebe87ff459e2960bR43-R45) [[3]](diffhunk://#diff-8bc8933bf9f0a1dece53f0af6a1cf667e51f3286cc1d8aacebe87ff459e2960bR58-R67)
* [`src/components/MediaRow.jsx`](diffhunk://#diff-8c58f480258d17d541fab43237fb979efcbf707a21d3031fb10ff62679ee0f3dL5-R10): Updated the `MediaRow` component to accept `setSelectedItem` as a prop and added a click handler to set the selected media item when the "View" button is clicked. [[1]](diffhunk://#diff-8c58f480258d17d541fab43237fb979efcbf707a21d3031fb10ff62679ee0f3dL5-R10) [[2]](diffhunk://#diff-8c58f480258d17d541fab43237fb979efcbf707a21d3031fb10ff62679ee0f3dR22-R31)